### PR TITLE
Develop

### DIFF
--- a/src/dataEstateModule.js
+++ b/src/dataEstateModule.js
@@ -468,7 +468,8 @@ de.factory('DeTaxonomy', function (DeApi) {
 		{ id: "in", name: "Instagram" }, { id: "fb", name: "Facebook" }, { id: "li", name: "LinkedIn" }, { id: "tw", name: "Twitter" }, { id: "yt", name: "YouTube" }
 	];
 	return {
-		subtypes: function () {
+		subtypes: function (category) {
+			var endpoints = "/taxonomy/data/"+category;
 			return subtypes;
 		},
 		locations: function () {

--- a/src/dataEstateModule.js
+++ b/src/dataEstateModule.js
@@ -470,7 +470,7 @@ de.factory('DeTaxonomy', function (DeApi) {
 	return {
 		subtypes: function (category) {
 			var endpoints = "/taxonomy/data/"+category;
-			return subtypes;
+			return DeApi.get(endpoints, {});
 		},
 		locations: function () {
 			return locations;


### PR DESCRIPTION
DeTaxonomy.subtypes were changed to just return flat variable, probably by mistake. This has been reverted back to call the taxonomy endpoint. 